### PR TITLE
Implement with react-native-gesture-handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ import {
   View,
   StyleSheet,
   Text,
-  PanResponder,
   Animated,
 } from 'react-native'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-scrubber",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Scrubber component for handling audio/video within React Native",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,11 @@
     "swipper",
     "controls"
   ],
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*",
+    "react-native-gesture-handler": "*"
+  },
   "author": "Repod",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Rewriting the animation logic using [the react-native-gesture-handler library](https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html) as opposed to the previously used React Native core PanResponder library.

Reasoning why:
The main reason why I've rewrote the logic using the gesture handler is because if any app is using the gesture handler heavily then they are going to see bugs when using both that library and this scrubber. Mostly other gesture handlers won't know when to relinquish control or stop handling when this component is active. The additional reason are that the gesture handler library has become increasing mature to the point where it is now the defacto way to handle touches and gestures. Along with being the defacto is is also very performant from a native aspect.

Merging this and bumping to 1.1.0. Stay on 1.0.0 for now if you absolutely need the PanResponder version. This new rework does not support scrubbing vertically to change the scrub rate right now. Will implement this in the future when I get more time. 