### PR TITLE
Added type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+import { Component } from 'react';
+import { TextStyle } from 'react-native';
+
+interface ScrubberProps {
+    value?: number;
+    bufferedValue?: number;
+    totalDuration?: number;
+    onSlidingComplete: (value: number) => void;
+    trackBackgroundColor?: string;
+    trackColor?: string;
+    bufferedTrackColor?: string;
+    scrubbedColor?: string;
+    displayedValueStyle?: TextStyle
+}
+
+declare class Scrubber extends Component<ScrubberProps, any> {}
+
+export = Scrubber

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-native": "*",
     "react-native-gesture-handler": "*"
   },
+  "types": "index.d.ts",
   "author": "Repod",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Hey, thanks for the package. Typescript was yelling at me when I tried to use it, because it doesn't have type declarations. I thought it would be good to add the type declarations. So that nobody has to `@ts-ignore`  :slightly_smiling_face:
