### PR TITLE
Updated formatValue variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const PLACEHOLDER_DISPLAY_VALUE = "--:--";
 const TrackSliderSize = 10;
 const SCALE_UP_DURAITON = 150;
 
-formatValue = (value) => {
+let formatValue = (value) => {
   const hours = Math.floor(value / 3600);
   const rawMinutes = value / 60 - 60 * hours;
   const minutes = Math.floor(rawMinutes);


### PR DESCRIPTION
I changed the formatValue variable to be declared using let because without this, an error is raised when trying to run the index.js file on the web using expo and react-native-web. The error is as follows:

"Unhandled Rejection (ReferenceError): formatValue is not defined"

Without this change, my app is not able to run on react-native-web, and with this change, it is. Since it is such a small, insignificant change I think it would be good for you guys to add it in the event that others run into the same issue 🙃.