### PR TITLE
Add scrubbing callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A video/audio scrubber for react native.
 - [x] Animate scrubber
 - [x] Handle buffered value
 - [x] Implement scrubbing
-- [ ] Scrubbing callbacks
+- [x] Scrubbing callbacks
 - [ ] Custom scrubbing thresholds and rates
 
 
@@ -33,7 +33,9 @@ Name | Type | Description
 `value` | Number | The current value of the video/audio.
 `bufferedValue` | Number | The current buffered value of the video/audio.
 `totalDuration` | Number | The total duration of the video/audio (Needed to calculated animations within the scrubber). **Note** If you supply a totalDuration of 0 the starting and ending number will display both as `--:--` since we require the totalDuration to display those numbers. 
-`onSlidingComplete` | Function | Callback that is called when the user releases the slider, regardless if the value has changed.
+`onSlidingStart` | Function | Optional callback that is called when the user starts scrubbing.
+`onSlide` | Function | Optional callback that is called while the user is scrubbing. The callback takes the current scrubbing position in seconds as its first argument.
+`onSlidingComplete` | Function | Callback that is called when the user releases the slider, regardless if the value has changed. The callback takes the current scrubbing position in seconds as its first argument.
 `trackBackgroundColor` | String | Hex color representing the color of the background (Unfilled) track
 `trackColor` | String | Hex color representing the color of the foregroud (Filled) track.
 `bufferedTrackColor` | String | Hex color representing the color of the buffered track which sits inbetween the background track and the progress track.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ interface ScrubberProps {
   bufferedValue?: number;
   totalDuration?: number;
   onSlidingComplete: (value: number) => void;
+  onSlidingStart?: (value: number) => any;
   tapNavigation?: boolean;
   trackBackgroundColor?: string;
   trackColor?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface ScrubberProps {
   bufferedValue?: number;
   totalDuration?: number;
   onSlidingComplete: (value: number) => void;
-  onSlidingStart?: (value: number) => any;
+  onSlidingStart?: () => any;
   tapNavigation?: boolean;
   trackBackgroundColor?: string;
   trackColor?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ interface ScrubberProps {
   totalDuration?: number;
   onSlidingComplete: (value: number) => void;
   onSlidingStart?: () => any;
+  onSlide?: (value: number) => any;
   tapNavigation?: boolean;
   trackBackgroundColor?: string;
   trackColor?: string;

--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ export default class extends Component {
       this._translateX.setValue(0);
 
       this.setState({ scrubbing: true }, this.scaleUp);
+      this.onSlidingStart();
     } else if (event.nativeEvent.state === State.ACTIVE) {
       this.panResonderMoved = true;
     } else if (event.nativeEvent.state === State.END) {
@@ -179,6 +180,10 @@ export default class extends Component {
   onSlidingComplete = (scrubbingValue) => {
     this.props.onSlidingComplete(scrubbingValue);
   };
+
+  onSlidingStart = () => {
+    this.props.onSlidingStart();
+  }
 
   onLayoutContainer = async (e) => {
     await this.setState({

--- a/index.js
+++ b/index.js
@@ -185,6 +185,10 @@ export default class extends Component {
     this.props.onSlidingStart();
   }
 
+  onSlide = (scrubbingValue) => {
+    this.props.onSlide(scrubbingValue);
+  }
+
   onLayoutContainer = async (e) => {
     await this.setState({
       dimensionWidth: e.nativeEvent.layout.width,
@@ -229,14 +233,17 @@ export default class extends Component {
         Math.max(value, 0),
         this.state.dimensionWidth
       );
+    
+      const startingNumberValue = (boundedValue / this.state.dimensionWidth) * this.props.totalDuration;
 
       this.setState({
-        startingNumberValue:
-          (boundedValue / this.state.dimensionWidth) * this.props.totalDuration,
+        startingNumberValue,
         endingNumberValue:
           (1 - boundedValue / this.state.dimensionWidth) *
           this.props.totalDuration,
       });
+    
+      this.onSlide(startingNumberValue);
       return;
     });
   };

--- a/index.js
+++ b/index.js
@@ -182,11 +182,15 @@ export default class extends Component {
   };
 
   onSlidingStart = () => {
-    this.props.onSlidingStart();
+    if (typeof this.props.onSlide === 'function') {
+      this.props.onSlidingStart();
+    }
   }
 
   onSlide = (scrubbingValue) => {
-    this.props.onSlide(scrubbingValue);
+    if (typeof this.props.onSlide === 'function') {
+      this.props.onSlide(scrubbingValue);
+    }
   }
 
   onLayoutContainer = async (e) => {


### PR DESCRIPTION
This adds two scrubbing callbacks. They can be passed as props to the Scrubber:
* `onSlideStart: () => any` is called when the user starts scrubbing.
* `onSlide: (value) => any` is called when the user is dragging the scrub nub and passes the value of the scrub position.
